### PR TITLE
Add blind structure configuration

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -113,8 +113,9 @@ function ConfigPage() {
         </label>
         <button type="submit" className="px-4 py-2 bg-emerald-600 rounded text-white">Save</button>
       </form>
-      <div className="mt-4">
+      <div className="mt-4 flex gap-4">
         <a href="index.html" className="underline">Back</a>
+        <a href="structure.html" className="underline">Structure</a>
       </div>
     </div>
   );

--- a/js/structure.js
+++ b/js/structure.js
@@ -1,0 +1,143 @@
+function StructureConfig() {
+  const defaultStructure = [
+    { round: 1, ante: 0, sb: 100, bb: 100 },
+    { round: 2, ante: 0, sb: 100, bb: 200 },
+    { round: 3, ante: 0, sb: 100, bb: 300 },
+    { round: 4, ante: 0, sb: 200, bb: 400 },
+    { round: 5, ante: 0, sb: 200, bb: 500 },
+    { round: 6, ante: 0, sb: 300, bb: 600 },
+    { round: 7, ante: 0, sb: 400, bb: 800 },
+    { round: 8, ante: 1000, sb: 500, bb: 1000 },
+    { round: 9, ante: 1200, sb: 600, bb: 1200 },
+    { round: 10, ante: 1600, sb: 800, bb: 1600 },
+    { round: 11, ante: 2000, sb: 1000, bb: 2000 },
+    { round: 12, ante: 2400, sb: 1200, bb: 2400 },
+    { round: 13, ante: 3000, sb: 1500, bb: 3000 },
+    { round: 14, ante: 4000, sb: 2000, bb: 4000 },
+    { round: 15, ante: 5000, sb: 2500, bb: 5000 },
+    { round: 16, ante: 6000, sb: 3000, bb: 6000 },
+    { round: 17, ante: 8000, sb: 4000, bb: 8000 },
+    { round: 18, ante: 10000, sb: 5000, bb: 10000 },
+  ];
+
+  const [levels, setLevels] = React.useState(() => {
+    try {
+      const stored = localStorage.getItem("tournamentStructure");
+      return stored ? JSON.parse(stored) : defaultStructure;
+    } catch {
+      return defaultStructure;
+    }
+  });
+
+  function updateLevels(updater) {
+    setLevels((ls) => {
+      const next = typeof updater === "function" ? updater(ls) : updater;
+      return next.map((lvl, i) => ({ ...lvl, round: i + 1 }));
+    });
+  }
+
+  function handleChange(index, field, value) {
+    updateLevels((ls) =>
+      ls.map((lvl, i) =>
+        i === index ? { ...lvl, [field]: parseInt(value, 10) || 0 } : lvl
+      )
+    );
+  }
+
+  function addRow() {
+    updateLevels([...levels, { round: levels.length + 1, ante: 0, sb: 0, bb: 0 }]);
+  }
+
+  function removeRow(index) {
+    updateLevels(levels.filter((_, i) => i !== index));
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    try {
+      localStorage.setItem("tournamentStructure", JSON.stringify(levels));
+    } catch {}
+    window.location.href = "index.html";
+  }
+
+  return (
+    <div className="p-4 sm:p-6">
+      <h1 className="text-2xl font-bold mb-4">Structure Settings</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <table className="w-full text-center">
+          <thead>
+            <tr>
+              <th className="px-2">Round</th>
+              <th className="px-2">Ante</th>
+              <th className="px-2">SB</th>
+              <th className="px-2">BB</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {levels.map((lvl, i) => (
+              <tr key={i}>
+                <td className="border px-2 py-1">{lvl.round}</td>
+                <td className="border px-2 py-1">
+                  <input
+                    type="number"
+                    value={lvl.ante}
+                    onChange={(e) => handleChange(i, "ante", e.target.value)}
+                    className="w-20 text-black px-1 rounded"
+                  />
+                </td>
+                <td className="border px-2 py-1">
+                  <input
+                    type="number"
+                    value={lvl.sb}
+                    onChange={(e) => handleChange(i, "sb", e.target.value)}
+                    className="w-20 text-black px-1 rounded"
+                  />
+                </td>
+                <td className="border px-2 py-1">
+                  <input
+                    type="number"
+                    value={lvl.bb}
+                    onChange={(e) => handleChange(i, "bb", e.target.value)}
+                    className="w-20 text-black px-1 rounded"
+                  />
+                </td>
+                <td className="border px-2 py-1">
+                  <button
+                    type="button"
+                    onClick={() => removeRow(i)}
+                    className="text-red-600"
+                  >
+                    X
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={addRow}
+            className="px-3 py-1 bg-neutral-700 rounded"
+          >
+            Add Row
+          </button>
+          <button type="submit" className="px-4 py-2 bg-emerald-600 rounded text-white">
+            Save
+          </button>
+          <a
+            href="config.html"
+            className="px-4 py-2 bg-neutral-700 rounded text-white text-center"
+          >
+            Back
+          </a>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <StructureConfig />
+);

--- a/js/tournament.js
+++ b/js/tournament.js
@@ -20,6 +20,35 @@ function TournamentManager() {
     }
   });
 
+  const defaultStructure = [
+    { round: 1, ante: 0, sb: 100, bb: 100 },
+    { round: 2, ante: 0, sb: 100, bb: 200 },
+    { round: 3, ante: 0, sb: 100, bb: 300 },
+    { round: 4, ante: 0, sb: 200, bb: 400 },
+    { round: 5, ante: 0, sb: 200, bb: 500 },
+    { round: 6, ante: 0, sb: 300, bb: 600 },
+    { round: 7, ante: 0, sb: 400, bb: 800 },
+    { round: 8, ante: 1000, sb: 500, bb: 1000 },
+    { round: 9, ante: 1200, sb: 600, bb: 1200 },
+    { round: 10, ante: 1600, sb: 800, bb: 1600 },
+    { round: 11, ante: 2000, sb: 1000, bb: 2000 },
+    { round: 12, ante: 2400, sb: 1200, bb: 2400 },
+    { round: 13, ante: 3000, sb: 1500, bb: 3000 },
+    { round: 14, ante: 4000, sb: 2000, bb: 4000 },
+    { round: 15, ante: 5000, sb: 2500, bb: 5000 },
+    { round: 16, ante: 6000, sb: 3000, bb: 6000 },
+    { round: 17, ante: 8000, sb: 4000, bb: 8000 },
+    { round: 18, ante: 10000, sb: 5000, bb: 10000 },
+  ];
+  const [structure] = React.useState(() => {
+    try {
+      const stored = localStorage.getItem("tournamentStructure");
+      return stored ? JSON.parse(stored) : defaultStructure;
+    } catch {
+      return defaultStructure;
+    }
+  });
+
   const players = React.useMemo(() => {
     return settings.players
       .split(/\n|,/) // split on newlines or commas
@@ -41,12 +70,15 @@ function TournamentManager() {
   const roundDuration = React.useMemo(() => parseTime(settings.roundTime), [settings.roundTime]);
 
   const levels = React.useMemo(
-    () => [
-      { name: 1, sb: 10, bb: 20, ante: 0, durationMs: roundDuration },
-      { name: 2, sb: 15, bb: 30, ante: 0, durationMs: roundDuration },
-      { name: 3, sb: 25, bb: 50, ante: 0, durationMs: roundDuration },
-    ],
-    [roundDuration]
+    () =>
+      structure.map((l) => ({
+        name: l.round,
+        sb: l.sb,
+        bb: l.bb,
+        ante: l.ante,
+        durationMs: roundDuration,
+      })),
+    [structure, roundDuration]
   );
 
   const [levelIndex, setLevelIndex] = React.useState(0);
@@ -179,6 +211,7 @@ function DisplayBoard({
         <div>{title}</div>
         <div className="flex items-center gap-4">
           <a href="config.html" className="text-base underline">Config</a>
+          <a href="structure.html" className="text-base underline">Structure</a>
           <div className="text-yellow-300">Players Remaining: {playersRemaining}</div>
         </div>
       </div>
@@ -196,8 +229,13 @@ function DisplayBoard({
       <div className="text-center mt-1 text-4xl font-extrabold">
         {isBreak ? "—" : `Blinds: ${currency}${level.sb} - ${currency}${level.bb}`}
       </div>
+      <div className="text-center mt-1 text-2xl">
+        {isBreak ? "—" : `Ante: ${currency}${level.ante}`}
+      </div>
       <div className="text-center mt-2 text-xl">
-        Next Round: {nextLevel?.break ? "Break" : `NLH`} · Next Blinds: {nextLevel?.break ? "—" : `${currency}${nextLevel?.sb ?? "-"} - ${currency}${nextLevel?.bb ?? "-"}`}
+        Next Round: {nextLevel?.break ? "Break" : `NLH`} · Next: {nextLevel?.break
+          ? "—"
+          : `Blinds ${currency}${nextLevel?.sb ?? "-"} - ${currency}${nextLevel?.bb ?? "-"}, Ante ${currency}${nextLevel?.ante ?? "-"}`}
       </div>
       <div className="grid grid-cols-2 gap-2 mt-6 text-xl">
         <Stat label="# Paid" value={Math.min(entries.buyIns, payoutPlaces || 5)} />

--- a/structure.html
+++ b/structure.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Structure Configuration</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body class="bg-green-700 text-white min-h-screen">
+    <div id="root"></div>
+    <script type="text/babel" src="js/structure.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add a dedicated Structure page to edit round/ante/sb/bb values with default levels stored in localStorage
- Load configured structure in the tournament view, displaying antes and providing links to the new page
- Link the existing config page to the structure editor for easier navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cdfd6e008324a4cf9e2837d53642