### PR TITLE
Integrate web dashboard with Telegram backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,78 @@
 # Poker Tournament Manager
 
-Simple React-based poker tournament manager. Open `index.html` to view the board or `config.html` to adjust settings.
+A combined web dashboard and Telegram bot for running multi-table poker tournaments. Tournament directors can drive blind level changes from the browser, while dealers receive synchronized round alerts and can report rebuys or eliminations either through Telegram or the web UI. All activity is persisted so the event survives restarts.
+
+## Features
+
+- **React scoreboard** with level timer, blind structure controls, prize pool stats, and quick actions for rebuys and eliminations.
+- **Telegram dealer bot** (powered by [Telegraf](https://telegraf.js.org)) that handles table assignments, round acknowledgements, and dealer actions.
+- **State persistence** to disk so dealer assignments, current round, rebuys, and eliminations are restored after a reboot.
+- **REST API** for programmatic control (`/round`, `/api/rebuys`, `/api/eliminations`, etc.) that mirrors the bot flows.
+- **Access controls** via an allow-list of Telegram IDs to keep the bot private to verified dealers.
+- **Recent activity feeds** so staff can review the last announcements and player movements.
+
+## Getting started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Set the required environment variables (see below) and start the backend:
+   ```bash
+   TELEGRAM_BOT_TOKEN=123456:ABC npm start
+   ```
+   The server listens on `http://localhost:3000` by default and also serves the static dashboard (`index.html`).
+3. Open `http://localhost:3000/` in a browser to access the tournament board. The board polls the backend for the latest state, so it should be accessed through the Express server rather than as a standalone `file://` URL.
+4. Start a conversation with your Telegram bot and use `/start` to pick a table. Only IDs included in the allow list (if configured) will be able to interact.
+
+## Environment variables
+
+| Variable | Description |
+| --- | --- |
+| `TELEGRAM_BOT_TOKEN` (or `BOT_TOKEN`) | **Required.** Telegram bot token provided by BotFather. |
+| `PORT` | Optional HTTP port for the Express server (default `3000`). |
+| `TOURNAMENT_STATE_FILE` | Optional path for the JSON persistence file (default `server/tournament-state.json`). |
+| `TOURNAMENT_TABLES` | Comma-separated list of table identifiers (default `1` through `10`). |
+| `TELEGRAM_ALLOWED_USER_IDS` / `ALLOWED_TELEGRAM_IDS` | Optional comma-separated list of Telegram numeric IDs allowed to use the bot. If unset, the bot is open to everyone. |
+| `TELEGRAM_UNAUTHORIZED_MESSAGE` | Optional custom denial message sent to unauthorized Telegram users. |
+| `STATIC_ROOT` | Override the directory served as static assets (defaults to the repository root). |
+
+## REST API overview
+
+All endpoints accept/return JSON and live under the same origin as the web app:
+
+- `POST /round` or `POST /api/rounds` – broadcast a new blind level (accepts `round`, `sb`, `bb`, `ante`, `tables`, etc.).
+- `POST /api/rebuys` – record a rebuy (`table` is required, `player`, `amount`, `notes` optional). Notifies the dealer for that table via Telegram.
+- `POST /api/eliminations` – record an elimination (requires `player`, optional `table`, `position`, `payout`, `notes`). Broadcasts to all dealers.
+- `GET /api/state` – full persisted state (`dealers`, `currentRound`, `rebuys`, `eliminations`).
+- `GET /api/dealers` – list current dealer assignments.
+- `POST /api/dealers` – manually assign a dealer (respects the allow list if enabled).
+- `DELETE /api/dealers/:id` – remove a dealer assignment.
+- `GET /api/health` – health check with dealer count.
+
+## Telegram bot usage
+
+- `/start` – choose a table from the inline keyboard (enforced so only one dealer occupies a table).
+- `/menu` or `/actions` – reopen the dealer action menu.
+- `/cancel` – abort the current inline prompt.
+- `/table` and `/status` – review your assignment or the latest round announcement.
+- `/recent` (alias `/history`) – view the most recent rebuys and eliminations, filtered to your table when applicable.
+
+The inline “Dealer actions” menu now includes:
+
+- **♻️ Rebuy** – prompt for player/amount and notify only the assigned dealer.
+- **❌ Eliminate Player** – record an elimination and broadcast to all dealers.
+- **🗒 Recent activity** – show the latest recorded rebuys and eliminations directly in Telegram.
+
+Unauthorized users attempting to access the bot receive a customizable denial message that includes their Telegram ID for easy whitelisting.
+
+## Web dashboard enhancements
+
+- The **Rebuy** button opens a form that submits to `/api/rebuys`, ensuring Telegram dealers are notified even when the staff uses the browser.
+- The new **Elimination** button records player knockouts via `/api/eliminations` and broadcasts them to every dealer.
+- A **Telegram sync summary** shows the broadcast round, tables notified, total rebuys/eliminations, and blind details pulled from the backend state.
+- **Dealer assignments** and **recent activity feeds** visualize the persisted data so TDs can monitor action across tables.
+
+## Persistence
+
+Tournament state is stored in the JSON file configured by `TOURNAMENT_STATE_FILE` (defaults to `server/tournament-state.json`). The file tracks dealer assignments, the last announced round, and a history of rebuys and eliminations so the operation can resume seamlessly after a restart.

--- a/js/tournament.js
+++ b/js/tournament.js
@@ -60,16 +60,22 @@ function TournamentManager() {
 
   const players = React.useMemo(() => {
     return settings.players
-      .split(/\n|,/) // split on newlines or commas
+      .split(/\n|,/)
       .map((p) => p.trim())
       .filter(Boolean);
   }, [settings.players]);
 
-  const [rebuys, setRebuys] = React.useState({});
-  const [addons, setAddons] = React.useState({});
-
-  const totalRebuys = Object.values(rebuys).reduce((a, b) => a + b, 0);
-  const totalAddons = Object.values(addons).reduce((a, b) => a + b, 0);
+  const [addons] = React.useState({});
+  const [backendState, setBackendState] = React.useState(null);
+  const [stateError, setStateError] = React.useState(null);
+  const [statusMessage, setStatusMessage] = React.useState(null);
+  const [statusType, setStatusType] = React.useState("success");
+  const [showRebuy, setShowRebuy] = React.useState(false);
+  const [showElimination, setShowElimination] = React.useState(false);
+  const [rebuyError, setRebuyError] = React.useState(null);
+  const [eliminationError, setEliminationError] = React.useState(null);
+  const [submittingRebuy, setSubmittingRebuy] = React.useState(false);
+  const [submittingElimination, setSubmittingElimination] = React.useState(false);
 
   function minutesToMs(min) {
     return (parseInt(min, 10) || 0) * 60 * 1000;
@@ -115,6 +121,79 @@ function TournamentManager() {
   }, [running]);
 
   const playersRemaining = players.length;
+
+  const refreshBackendState = React.useCallback(async () => {
+    if (
+      typeof window !== "undefined" &&
+      window.location &&
+      window.location.protocol === "file:"
+    ) {
+      setStateError(
+        "Connect to the Express server (npm start) to sync Telegram updates from the backend."
+      );
+      return;
+    }
+    try {
+      const response = await fetch("/api/state", { cache: "no-store" });
+      if (!response.ok) {
+        let message = `Failed to load backend state (status ${response.status}).`;
+        try {
+          const data = await response.json();
+          if (data && data.error) {
+            message = data.error;
+          }
+        } catch (error) {
+          // Ignore JSON parse errors.
+        }
+        throw new Error(message);
+      }
+      const data = await response.json();
+      setBackendState(data);
+      setStateError(null);
+    } catch (error) {
+      console.error("Failed to load backend state", error);
+      setStateError(error.message || "Failed to load backend state.");
+    }
+  }, []);
+
+  React.useEffect(() => {
+    refreshBackendState();
+    const interval = setInterval(() => {
+      refreshBackendState();
+    }, 15000);
+    return () => clearInterval(interval);
+  }, [refreshBackendState]);
+
+  React.useEffect(() => {
+    if (!statusMessage) return;
+    const id = setTimeout(() => setStatusMessage(null), 6000);
+    return () => clearTimeout(id);
+  }, [statusMessage]);
+
+  const backendRebuys = Array.isArray(backendState?.rebuys) ? backendState.rebuys : [];
+  const backendEliminations = Array.isArray(backendState?.eliminations)
+    ? backendState.eliminations
+    : [];
+  const dealers = React.useMemo(() => {
+    const list = Array.isArray(backendState?.dealers) ? [...backendState.dealers] : [];
+    return list.sort((a, b) => {
+      const tableA = (a.table ?? "").toString();
+      const tableB = (b.table ?? "").toString();
+      if (tableA === tableB) {
+        return (a.id ?? "").toString().localeCompare((b.id ?? "").toString());
+      }
+      const numA = parseInt(tableA, 10);
+      const numB = parseInt(tableB, 10);
+      if (!Number.isNaN(numA) && !Number.isNaN(numB)) {
+        return numA - numB;
+      }
+      return tableA.localeCompare(tableB);
+    });
+  }, [backendState]);
+
+  const totalRebuys = backendRebuys.length;
+  const totalAddons = Object.values(addons).reduce((a, b) => a + b, 0);
+
   const entries = React.useMemo(
     () => ({ buyIns: players.length + totalRebuys }),
     [players.length, totalRebuys]
@@ -124,13 +203,13 @@ function TournamentManager() {
     totalRebuys * (parseInt(settings.rebuyValue, 10) || 0) +
     totalAddons * (parseInt(settings.addonValue, 10) || 0);
   const totalChips =
-    (players.length + totalRebuys + totalAddons) *
-    (parseInt(settings.startingChips, 10) || 0);
+    (players.length + totalRebuys + totalAddons) * (parseInt(settings.startingChips, 10) || 0);
   const nextBreakETA = "-";
 
   function handlePrevLevel() {
     setLevelIndex((i) => Math.max(0, i - 1));
   }
+
   function postRoundUpdate(level, index) {
     if (!level) {
       return;
@@ -187,10 +266,16 @@ function TournamentManager() {
           throw new Error(message);
         }
       })
+      .then(() => {
+        refreshBackendState();
+      })
       .catch((error) => {
         console.error("Failed to announce round", error);
+        setStatusType("error");
+        setStatusMessage(error.message || "Failed to announce round.");
       });
   }
+
   function handleNextLevel() {
     setLevelIndex((i) => {
       const nextIndex = Math.min(levels.length - 1, i + 1);
@@ -201,18 +286,89 @@ function TournamentManager() {
       return nextIndex;
     });
   }
+
   function resetLevelTimer() {
     setRemainingMs(curLevel.durationMs);
   }
 
-  const [showRebuy, setShowRebuy] = React.useState(false);
   function openRebuy() {
+    setRebuyError(null);
     setShowRebuy(true);
   }
-  function handleRebuy(name) {
-    setRebuys((r) => ({ ...r, [name]: (r[name] || 0) + 1 }));
-    setShowRebuy(false);
+
+  function openElimination() {
+    setEliminationError(null);
+    setShowElimination(true);
   }
+
+  const handleSubmitRebuy = React.useCallback(
+    async ({ table, player, amount, notes }) => {
+      setSubmittingRebuy(true);
+      setRebuyError(null);
+      try {
+        const payload = {
+          table: table?.trim() || "",
+          player: player?.trim() || "",
+          amount: amount?.trim() || "",
+          notes: notes?.trim() || "",
+        };
+        const data = await postJson("/api/rebuys", payload);
+        setShowRebuy(false);
+        const tableLabel = data?.rebuy?.table || payload.table;
+        const messageParts = [`Rebuy recorded for table ${tableLabel || "?"}.`];
+        if (Array.isArray(data?.failures) && data.failures.length > 0) {
+          messageParts.push("⚠️ Telegram delivery issues — please confirm manually.");
+        } else if (Array.isArray(data?.notified) && data.notified.length > 0) {
+          messageParts.push("Telegram notification sent.");
+        }
+        setStatusType("success");
+        setStatusMessage(messageParts.join(" "));
+        await refreshBackendState();
+      } catch (error) {
+        const message = error?.message || "Failed to record rebuy.";
+        setRebuyError(message);
+      } finally {
+        setSubmittingRebuy(false);
+      }
+    },
+    [refreshBackendState]
+  );
+
+  const handleSubmitElimination = React.useCallback(
+    async ({ table, player, position, payout, notes }) => {
+      setSubmittingElimination(true);
+      setEliminationError(null);
+      try {
+        const payload = {
+          table: table?.trim() || "",
+          player: player?.trim() || "",
+          position: position?.trim() || "",
+          payout: payout?.trim() || "",
+          notes: notes?.trim() || "",
+        };
+        const data = await postJson("/api/eliminations", payload);
+        setShowElimination(false);
+        const playerLabel = data?.elimination?.player || payload.player || "Unknown";
+        const messageParts = [`Elimination recorded for ${playerLabel}.`];
+        if (Array.isArray(data?.failures) && data.failures.length > 0) {
+          messageParts.push("⚠️ Some dealers did not receive the Telegram alert.");
+        } else if (Array.isArray(data?.notified) && data.notified.length > 0) {
+          messageParts.push("Broadcast delivered to all dealers.");
+        }
+        setStatusType("success");
+        setStatusMessage(messageParts.join(" "));
+        await refreshBackendState();
+      } catch (error) {
+        const message = error?.message || "Failed to record elimination.";
+        setEliminationError(message);
+      } finally {
+        setSubmittingElimination(false);
+      }
+    },
+    [refreshBackendState]
+  );
+
+  const broadcastRound = backendState?.currentRound ?? null;
 
   return (
     <div className="p-3 sm:p-6">
@@ -234,32 +390,46 @@ function TournamentManager() {
         onNext={handleNextLevel}
         onReset={resetLevelTimer}
         onRebuy={openRebuy}
+        onElimination={openElimination}
         payoutPlaces={settings.payoutPlaces}
+        broadcastRound={broadcastRound}
       />
+      {statusMessage && <StatusBanner type={statusType}>{statusMessage}</StatusBanner>}
+      {stateError && <StatusBanner type="error">{stateError}</StatusBanner>}
+      <div className="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <RoundSummary
+          broadcastRound={broadcastRound}
+          rebuys={backendRebuys}
+          eliminations={backendEliminations}
+        />
+        <DealerAssignments dealers={dealers} />
+      </div>
+      <ActivityFeed rebuys={backendRebuys} eliminations={backendEliminations} />
       {showRebuy && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center">
-          <div className="bg-white text-black p-4 rounded w-64">
-            <h2 className="text-xl mb-2">Select player</h2>
-            <ul className="flex flex-col gap-2 max-h-64 overflow-auto">
-              {players.map((p) => (
-                <li key={p}>
-                  <button
-                    onClick={() => handleRebuy(p)}
-                    className="w-full px-3 py-1 bg-emerald-600 text-white rounded"
-                  >
-                    {p}
-                  </button>
-                </li>
-              ))}
-            </ul>
-            <button
-              onClick={() => setShowRebuy(false)}
-              className="mt-3 underline"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+        <RebuyModal
+          players={players}
+          dealers={dealers}
+          onClose={() => {
+            setShowRebuy(false);
+            setRebuyError(null);
+          }}
+          onSubmit={handleSubmitRebuy}
+          submitting={submittingRebuy}
+          error={rebuyError}
+        />
+      )}
+      {showElimination && (
+        <EliminationModal
+          players={players}
+          dealers={dealers}
+          onClose={() => {
+            setShowElimination(false);
+            setEliminationError(null);
+          }}
+          onSubmit={handleSubmitElimination}
+          submitting={submittingElimination}
+          error={eliminationError}
+        />
       )}
     </div>
   );
@@ -284,11 +454,11 @@ function DisplayBoard({
   onReset,
   payoutPlaces,
   onRebuy,
+  onElimination,
+  broadcastRound,
 }) {
   const isBreak = !!level.break;
-  const [localTime, setLocalTime] = React.useState(
-    () => new Date()
-  );
+  const [localTime, setLocalTime] = React.useState(() => new Date());
   React.useEffect(() => {
     const id = setInterval(() => setLocalTime(new Date()), 1000);
     return () => clearInterval(id);
@@ -301,21 +471,36 @@ function DisplayBoard({
       }),
     [localTime]
   );
+  const broadcastLabel = describeBroadcastRound(broadcastRound);
+  const broadcastTables = formatTablesList(broadcastRound?.tables);
+  const broadcastUpdatedAt = broadcastRound?.updatedAt
+    ? formatTimestamp(broadcastRound.updatedAt)
+    : null;
   return (
     <div className="rounded-2xl shadow-xl p-4 sm:p-6 bg-black/70 text-white border border-white/10">
-      <div className="flex items-center justify-between text-3xl font-bold">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between text-3xl font-bold">
         <div>{title}</div>
-        <div className="flex items-center gap-4">
-          <a href="config.html" className="text-base underline">Config</a>
-          <a href="structure.html" className="text-base underline">Structure</a>
+        <div className="flex flex-wrap items-center gap-4 text-base lg:text-lg">
+          <a href="config.html" className="underline">
+            Config
+          </a>
+          <a href="structure.html" className="underline">
+            Structure
+          </a>
           <div className="text-yellow-300">Players Remaining: {playersRemaining}</div>
         </div>
       </div>
-      <div className="my-4 grid grid-cols-2 gap-2 text-lg">
+      <div className="my-4 grid grid-cols-2 lg:grid-cols-4 gap-2 text-lg">
         <InfoPill label="Round" value={level.name || "-"} />
+        <InfoPill label="Telegram Round" value={broadcastLabel} />
         <InfoPill label="Next Break" value={nextBreakETA} />
         <InfoPill label="# Entries" value={`${entries.buyIns}`} />
       </div>
+      {broadcastUpdatedAt && (
+        <div className="text-sm text-white/70 mb-2">
+          Telegram tables: {broadcastTables} · Last update {broadcastUpdatedAt}
+        </div>
+      )}
       <div className="bg-black rounded-xl py-6 text-center">
         <div className="text-[12vw] leading-none font-black">{fmtMS(remainingMs)}</div>
         <div className="text-sm mt-1">({localStr})</div>
@@ -340,17 +525,32 @@ function DisplayBoard({
         <Stat label="Prize Pool" value={`${currency}${formatNumber(prizePool)}`} />
         <div className="flex items-center justify-center gap-2">
           {running ? (
-            <button onClick={onPause} className="px-4 py-2 rounded-xl bg-red-600">Pause</button>
+            <button onClick={onPause} className="px-4 py-2 rounded-xl bg-red-600">
+              Pause
+            </button>
           ) : (
-            <button onClick={onResume} className="px-4 py-2 rounded-xl bg-emerald-600">Resume</button>
+            <button onClick={onResume} className="px-4 py-2 rounded-xl bg-emerald-600">
+              Resume
+            </button>
           )}
-          <button onClick={onReset} className="px-3 py-2 rounded-xl bg-neutral-700">Reset</button>
+          <button onClick={onReset} className="px-3 py-2 rounded-xl bg-neutral-700">
+            Reset
+          </button>
         </div>
       </div>
-      <div className="flex gap-2 mt-4 justify-center">
-        <button onClick={onPrev} className="px-3 py-2 rounded-xl bg-neutral-700">Prev</button>
-        <button onClick={onRebuy} className="px-3 py-2 rounded-xl bg-neutral-700">Rebuy</button>
-        <button onClick={onNext} className="px-3 py-2 rounded-xl bg-neutral-700">Next</button>
+      <div className="flex flex-wrap gap-2 mt-4 justify-center">
+        <button onClick={onPrev} className="px-3 py-2 rounded-xl bg-neutral-700">
+          Prev
+        </button>
+        <button onClick={onRebuy} className="px-3 py-2 rounded-xl bg-neutral-700">
+          Rebuy
+        </button>
+        <button onClick={onElimination} className="px-3 py-2 rounded-xl bg-neutral-700">
+          Elimination
+        </button>
+        <button onClick={onNext} className="px-3 py-2 rounded-xl bg-neutral-700">
+          Next
+        </button>
       </div>
     </div>
   );
@@ -374,6 +574,535 @@ function Stat({ label, value }) {
   );
 }
 
+function StatusBanner({ type = "info", children }) {
+  const background =
+    type === "error"
+      ? "bg-red-700"
+      : type === "success"
+      ? "bg-emerald-700"
+      : "bg-neutral-700";
+  return (
+    <div className={`${background} border border-white/10 rounded-xl px-4 py-3 mt-4 text-center text-sm`}>
+      {children}
+    </div>
+  );
+}
+
+function RoundSummary({ broadcastRound, rebuys, eliminations }) {
+  const blinds = broadcastRound?.blinds;
+  const smallBlind = broadcastRound?.smallBlind;
+  const bigBlind = broadcastRound?.bigBlind;
+  const ante = broadcastRound?.ante;
+  const notes = broadcastRound?.notes;
+  const startTime = broadcastRound?.startTime;
+  return (
+    <SectionCard title="Telegram sync">
+      <dl className="space-y-2 text-sm">
+        <div className="flex items-center justify-between gap-2">
+          <dt className="text-white/70">Current round</dt>
+          <dd className="font-semibold">{describeBroadcastRound(broadcastRound)}</dd>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <dt className="text-white/70">Tables notified</dt>
+          <dd>{formatTablesList(broadcastRound?.tables)}</dd>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <dt className="text-white/70">Rebuys recorded</dt>
+          <dd>{rebuys.length}</dd>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <dt className="text-white/70">Eliminations recorded</dt>
+          <dd>{eliminations.length}</dd>
+        </div>
+        {blinds && (
+          <div className="flex items-center justify-between gap-2">
+            <dt className="text-white/70">Blinds</dt>
+            <dd>{blinds}</dd>
+          </div>
+        )}
+        {!blinds && (smallBlind || bigBlind) && (
+          <div className="flex items-center justify-between gap-2">
+            <dt className="text-white/70">Blinds</dt>
+            <dd>
+              {smallBlind ?? "-"}/{bigBlind ?? "-"}
+            </dd>
+          </div>
+        )}
+        {ante && (
+          <div className="flex items-center justify-between gap-2">
+            <dt className="text-white/70">Ante</dt>
+            <dd>{ante}</dd>
+          </div>
+        )}
+        {startTime && (
+          <div className="flex items-center justify-between gap-2">
+            <dt className="text-white/70">Start time</dt>
+            <dd>{startTime}</dd>
+          </div>
+        )}
+        {notes && <div className="text-white/80 whitespace-pre-wrap">{notes}</div>}
+        {broadcastRound?.updatedAt && (
+          <div className="text-xs text-white/60">
+            Last update {formatTimestamp(broadcastRound.updatedAt)}
+          </div>
+        )}
+      </dl>
+    </SectionCard>
+  );
+}
+
+function DealerAssignments({ dealers }) {
+  const hasDealers = Array.isArray(dealers) && dealers.length > 0;
+  return (
+    <SectionCard title="Dealer assignments">
+      {hasDealers ? (
+        <ul className="flex flex-col gap-2 text-sm">
+          {dealers.map((dealer) => (
+            <li
+              key={dealer.id || dealer.chatId}
+              className="flex items-center justify-between gap-3 border border-white/10 rounded-lg px-3 py-2 bg-white/5"
+            >
+              <div className="font-semibold">Table {dealer.table || "—"}</div>
+              <div className="text-white/80">{formatDealerName(dealer)}</div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-white/70">No dealers have registered yet.</p>
+      )}
+    </SectionCard>
+  );
+}
+
+function ActivityFeed({ rebuys, eliminations }) {
+  const recentRebuys = Array.isArray(rebuys) ? [...rebuys].slice(-10).reverse() : [];
+  const recentEliminations = Array.isArray(eliminations)
+    ? [...eliminations].slice(-10).reverse()
+    : [];
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
+      <SectionCard title="Recent rebuys">
+        {recentRebuys.length === 0 ? (
+          <p className="text-sm text-white/70">No rebuys recorded yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-2 text-sm">
+            {recentRebuys.map((rebuy, index) => (
+              <li
+                key={`${rebuy.createdAt || "rebuy"}-${index}`}
+                className="border border-white/10 rounded-lg p-3 bg-white/5"
+              >
+                <div className="font-semibold">Table {rebuy.table || "—"}</div>
+                {rebuy.player && <div>Player: {rebuy.player}</div>}
+                {rebuy.amount && <div>Amount: {rebuy.amount}</div>}
+                {rebuy.notes && (
+                  <div className="text-white/80 whitespace-pre-wrap">{rebuy.notes}</div>
+                )}
+                {rebuy.createdAt && (
+                  <div className="text-xs text-white/60 mt-1">
+                    {formatTimestamp(rebuy.createdAt)}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </SectionCard>
+      <SectionCard title="Recent eliminations">
+        {recentEliminations.length === 0 ? (
+          <p className="text-sm text-white/70">No eliminations recorded yet.</p>
+        ) : (
+          <ul className="flex flex-col gap-2 text-sm">
+            {recentEliminations.map((elimination, index) => (
+              <li
+                key={`${elimination.createdAt || "elim"}-${index}`}
+                className="border border-white/10 rounded-lg p-3 bg-white/5"
+              >
+                <div className="font-semibold">{elimination.player || "Unknown player"}</div>
+                {elimination.table && <div>Table {elimination.table}</div>}
+                {elimination.position && <div>Position #{elimination.position}</div>}
+                {elimination.payout && <div>Payout: {elimination.payout}</div>}
+                {elimination.notes && (
+                  <div className="text-white/80 whitespace-pre-wrap">{elimination.notes}</div>
+                )}
+                {elimination.createdAt && (
+                  <div className="text-xs text-white/60 mt-1">
+                    {formatTimestamp(elimination.createdAt)}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </SectionCard>
+    </div>
+  );
+}
+
+function RebuyModal({ players, dealers, onClose, onSubmit, submitting, error }) {
+  const [table, setTable] = React.useState(() => (dealers[0]?.table ? `${dealers[0].table}` : ""));
+  const [player, setPlayer] = React.useState("");
+  const [amount, setAmount] = React.useState("");
+  const [notes, setNotes] = React.useState("");
+  const [search, setSearch] = React.useState("");
+  const [formError, setFormError] = React.useState(null);
+
+  React.useEffect(() => {
+    setFormError(error || null);
+  }, [error]);
+
+  React.useEffect(() => {
+    if (!table && dealers[0]?.table) {
+      setTable(`${dealers[0].table}`);
+    }
+  }, [dealers, table]);
+
+  const filteredPlayers = React.useMemo(() => {
+    if (!search) {
+      return players;
+    }
+    const query = search.toLowerCase();
+    return players.filter((p) => p.toLowerCase().includes(query));
+  }, [players, search]);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    if (!table.trim()) {
+      setFormError("Please choose a table before recording a rebuy.");
+      return;
+    }
+    if (!player.trim()) {
+      setFormError("Please choose or enter a player name or seat.");
+      return;
+    }
+    setFormError(null);
+    await onSubmit({ table, player, amount, notes });
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="bg-white text-black p-4 sm:p-6 rounded-xl w-full max-w-md shadow-2xl">
+        <h2 className="text-xl font-semibold mb-3">Record rebuy</h2>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold">Table</span>
+            <input
+              list="rebuy-table-options"
+              value={table}
+              onChange={(event) => setTable(event.target.value)}
+              className="border rounded px-3 py-2"
+              placeholder="Enter table"
+              disabled={submitting}
+            />
+            <datalist id="rebuy-table-options">
+              {dealers.map((dealer) => (
+                <option key={dealer.id || dealer.table} value={dealer.table}>
+                  {dealer.table ? `Table ${dealer.table} — ${formatDealerName(dealer)}` : formatDealerName(dealer)}
+                </option>
+              ))}
+            </datalist>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold">Player</span>
+            <input
+              value={player}
+              onChange={(event) => setPlayer(event.target.value)}
+              className="border rounded px-3 py-2"
+              placeholder="Player name or seat"
+              disabled={submitting}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold">Amount (optional)</span>
+            <input
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              className="border rounded px-3 py-2"
+              placeholder="Amount collected"
+              disabled={submitting}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold">Notes (optional)</span>
+            <textarea
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              className="border rounded px-3 py-2"
+              rows={3}
+              placeholder="Additional details"
+              disabled={submitting}
+            />
+          </label>
+          {formError && <div className="text-sm text-red-600">{formError}</div>}
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={onClose} className="px-3 py-2 underline">
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-3 py-2 rounded bg-emerald-600 text-white"
+              disabled={submitting}
+            >
+              {submitting ? "Recording..." : "Record rebuy"}
+            </button>
+          </div>
+        </form>
+        {players.length > 0 && (
+          <div className="mt-4">
+            <h3 className="font-semibold text-sm mb-1">Quick select</h3>
+            <input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              className="border rounded px-3 py-2 w-full mb-2"
+              placeholder="Search players"
+              disabled={submitting}
+            />
+            <div className="max-h-40 overflow-auto border rounded">
+              {filteredPlayers.map((name) => (
+                <button
+                  key={name}
+                  type="button"
+                  onClick={() => setPlayer(name)}
+                  className="block w-full text-left px-3 py-2 hover:bg-emerald-100"
+                  disabled={submitting}
+                >
+                  {name}
+                </button>
+              ))}
+              {filteredPlayers.length === 0 && (
+                <div className="px-3 py-2 text-sm text-neutral-500">No players match the filter.</div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EliminationModal({ players, dealers, onClose, onSubmit, submitting, error }) {
+  const [table, setTable] = React.useState("");
+  const [player, setPlayer] = React.useState("");
+  const [position, setPosition] = React.useState("");
+  const [payout, setPayout] = React.useState("");
+  const [notes, setNotes] = React.useState("");
+  const [search, setSearch] = React.useState("");
+  const [formError, setFormError] = React.useState(null);
+
+  React.useEffect(() => {
+    setFormError(error || null);
+  }, [error]);
+
+  const filteredPlayers = React.useMemo(() => {
+    if (!search) {
+      return players;
+    }
+    const query = search.toLowerCase();
+    return players.filter((p) => p.toLowerCase().includes(query));
+  }, [players, search]);
+
+  async function handleSubmit(event) {
+    event.preventDefault();
+    if (!player.trim()) {
+      setFormError("Please enter the eliminated player or seat number.");
+      return;
+    }
+    setFormError(null);
+    await onSubmit({ table, player, position, payout, notes });
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="bg-white text-black p-4 sm:p-6 rounded-xl w-full max-w-lg shadow-2xl">
+        <h2 className="text-xl font-semibold mb-3">Record elimination</h2>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold">Table (optional)</span>
+            <input
+              list="elimination-table-options"
+              value={table}
+              onChange={(event) => setTable(event.target.value)}
+              className="border rounded px-3 py-2"
+              placeholder="Enter table"
+              disabled={submitting}
+            />
+            <datalist id="elimination-table-options">
+              {dealers.map((dealer) => (
+                <option key={dealer.id || dealer.table} value={dealer.table}>
+                  {dealer.table ? `Table ${dealer.table} — ${formatDealerName(dealer)}` : formatDealerName(dealer)}
+                </option>
+              ))}
+            </datalist>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold">Player</span>
+            <input
+              value={player}
+              onChange={(event) => setPlayer(event.target.value)}
+              className="border rounded px-3 py-2"
+              placeholder="Player name or seat"
+              disabled={submitting}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold">Finish position (optional)</span>
+            <input
+              value={position}
+              onChange={(event) => setPosition(event.target.value)}
+              className="border rounded px-3 py-2"
+              placeholder="# / place"
+              disabled={submitting}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold">Payout (optional)</span>
+            <input
+              value={payout}
+              onChange={(event) => setPayout(event.target.value)}
+              className="border rounded px-3 py-2"
+              placeholder="Payout"
+              disabled={submitting}
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-semibold">Notes (optional)</span>
+            <textarea
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              className="border rounded px-3 py-2"
+              rows={3}
+              placeholder="Additional context"
+              disabled={submitting}
+            />
+          </label>
+          {formError && <div className="text-sm text-red-600">{formError}</div>}
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={onClose} className="px-3 py-2 underline">
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-3 py-2 rounded bg-red-600 text-white"
+              disabled={submitting}
+            >
+              {submitting ? "Recording..." : "Record elimination"}
+            </button>
+          </div>
+        </form>
+        {players.length > 0 && (
+          <div className="mt-4">
+            <h3 className="font-semibold text-sm mb-1">Quick select</h3>
+            <input
+              type="search"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              className="border rounded px-3 py-2 w-full mb-2"
+              placeholder="Search players"
+              disabled={submitting}
+            />
+            <div className="max-h-40 overflow-auto border rounded">
+              {filteredPlayers.map((name) => (
+                <button
+                  key={name}
+                  type="button"
+                  onClick={() => setPlayer(name)}
+                  className="block w-full text-left px-3 py-2 hover:bg-red-100"
+                  disabled={submitting}
+                >
+                  {name}
+                </button>
+              ))}
+              {filteredPlayers.length === 0 && (
+                <div className="px-3 py-2 text-sm text-neutral-500">No players match the filter.</div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SectionCard({ title, children }) {
+  return (
+    <div className="bg-black/60 border border-white/10 rounded-2xl p-4">
+      <h3 className="text-lg font-semibold mb-3">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function formatDealerName(dealer = {}) {
+  const parts = [];
+  if (dealer.firstName) {
+    parts.push(dealer.firstName);
+  }
+  if (dealer.lastName) {
+    parts.push(dealer.lastName);
+  }
+  if (parts.length > 0) {
+    return parts.join(" ");
+  }
+  if (dealer.username) {
+    return `@${dealer.username}`;
+  }
+  return dealer.id || dealer.chatId || "Unknown dealer";
+}
+
+function formatTimestamp(value) {
+  if (!value) {
+    return "";
+  }
+  try {
+    return new Date(value).toLocaleString([], {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch (error) {
+    return String(value);
+  }
+}
+
+function describeBroadcastRound(round) {
+  if (!round) {
+    return "—";
+  }
+  if (round.isBreak) {
+    return "Break";
+  }
+  return round.name || round.round || round.roundNumber || "Update";
+}
+
+function formatTablesList(tables) {
+  if (!Array.isArray(tables) || tables.length === 0) {
+    return "All tables";
+  }
+  return tables.join(", ");
+}
+
+async function postJson(url, payload) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    let message = `Request failed with status ${response.status}`;
+    try {
+      const data = await response.json();
+      if (data && data.error) {
+        message = data.error;
+      }
+    } catch (error) {
+      // Ignore JSON errors and fall back to generic message.
+    }
+    throw new Error(message);
+  }
+  return response.json();
+}
+
 function fmtMS(ms) {
   const total = Math.max(0, Math.floor(ms / 1000));
   const m = Math.floor(total / 60);
@@ -384,7 +1113,7 @@ function fmtMS(ms) {
 function formatNumber(n) {
   try {
     return n.toLocaleString();
-  } catch {
+  } catch (error) {
     return String(n);
   }
 }


### PR DESCRIPTION
## Summary
- gate Telegram bot usage behind an optional allow list, add a recent activity action/command, and serve the dashboard statically from Express
- wire the React tournament board to poll `/api/state`, submit rebuys and eliminations through the new APIs, and surface dealer assignments plus recent activity panels
- document environment variables, REST endpoints, and the combined web/Telegram workflow in the README for tournament staff

## Testing
- not run (TELEGRAM_BOT_TOKEN required to start the server)


------
https://chatgpt.com/codex/tasks/task_e_68c9f879eb788324bf8e67c87a50c807