### PR TITLE
Add add-on support and normalize blind structure

### DIFF
--- a/appconfig.yaml
+++ b/appconfig.yaml
@@ -14,30 +14,108 @@ number_of_tables: 2
 buy_in:
   amount: 250
   chips: 25000
-  currency: "₪"
+  currency: "฿"
 rebuy:
   enabled: true
   amount: 250
   chips: 25000
+  currency: "฿"
+addon:
+  enabled: true
+  amount: 500
+  chips: 10000
+  currency: "฿"
 structure:
-  - level: 1
-    small_blind: 25
-    big_blind: 50
+  - round: 1
     ante: 0
-    duration_minutes: 20
-  - level: 2
-    small_blind: 50
-    big_blind: 100
+    sb: 100
+    bb: 100
+    time: 15
+  - round: 2
     ante: 0
-    duration_minutes: 20
-  - level: 3
-    small_blind: 75
-    big_blind: 150
+    sb: 100
+    bb: 200
+    time: 15
+  - round: 3
     ante: 0
-    duration_minutes: 20
-  - level: 4
-    small_blind: 100
-    big_blind: 200
+    sb: 100
+    bb: 300
+    time: 15
+  - round: 4
     ante: 0
-    duration_minutes: 20
+    sb: 200
+    bb: 400
+    time: 15
+  - round: 5
+    ante: 0
+    sb: 200
+    bb: 500
+    time: 15
+  - round: 6
+    ante: 0
+    sb: 300
+    bb: 600
+    time: 15
+  - round: 7
+    ante: 0
+    sb: 400
+    bb: 800
+    time: 15
+  - break: true
+    time: 10
+  - round: 8
+    ante: 1000
+    sb: 500
+    bb: 1000
+    time: 15
+  - round: 9
+    ante: 1200
+    sb: 600
+    bb: 1200
+    time: 15
+  - round: 10
+    ante: 1600
+    sb: 800
+    bb: 1600
+    time: 15
+  - round: 11
+    ante: 2000
+    sb: 1000
+    bb: 2000
+    time: 15
+  - round: 12
+    ante: 2400
+    sb: 1200
+    bb: 2400
+    time: 15
+  - round: 13
+    ante: 3000
+    sb: 1500
+    bb: 3000
+    time: 15
+  - round: 14
+    ante: 4000
+    sb: 2000
+    bb: 4000
+    time: 15
+  - round: 15
+    ante: 5000
+    sb: 2500
+    bb: 5000
+    time: 15
+  - round: 16
+    ante: 6000
+    sb: 3000
+    bb: 6000
+    time: 15
+  - round: 17
+    ante: 8000
+    sb: 4000
+    bb: 8000
+    time: 15
+  - round: 18
+    ante: 10000
+    sb: 5000
+    bb: 10000
+    time: 15
 players: *players


### PR DESCRIPTION
## Summary
- add Thai Baht denominations and default add-on configuration to the app config
- support add-on tracking alongside existing rebuy flow and include totals in the metrics panel
- normalize structure entries to handle round/break definitions and refresh the metrics message every minute

## Testing
- not run (starting the bot would attempt to reach Telegram)


------
https://chatgpt.com/codex/tasks/task_e_68ca91e4a4fc8324b3e6818eb88b697b