### PR TITLE
Improve tournament heartbeat feedback and logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 server/tournament-state.json
 .env
 npm-debug.log
+logs/


### PR DESCRIPTION
## Summary
- enlarge the timer, add heartbeat notifications, and surface backend update timestamps with a restart confirmation control
- refresh the stat cards with icons and add a detailed rebuy overview including cash totals per player
- log every rebuy/add-on to logs/rebuy-addon.log so issues can be audited later and ignore generated logs in git

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ca97e889d4832494a7c22743a3baa1