### PR TITLE
Add role-based access control to tournament bot

### DIFF
--- a/appconfig.yaml
+++ b/appconfig.yaml
@@ -1,4 +1,5 @@
 bot_token: 8348230320:AAE6k8KwF9t-grjIJ3JSuEGBAfUMqUpFKRc
+dealer_password: "7788"
 player: &players
   - חן
   - קנטור


### PR DESCRIPTION
## Summary
- add a role-selection flow for /start and /role with dealer authentication via the configured password
- restrict tournament management actions to authenticated dealers and expose read-only “show” actions for players
- provide formatted history responses and a dynamic inline keyboard that surfaces viewer/admin controls appropriately

## Testing
- node --check server/index.js

------
https://chatgpt.com/codex/tasks/task_e_68ca9b81dc1c83249e3f722d07a49bf4