### PR TITLE
Add game selection, reset controls, and versioned start banner

### DIFF
--- a/appconfig.yaml
+++ b/appconfig.yaml
@@ -1,5 +1,8 @@
 bot_token: 8348230320:AAE6k8KwF9t-grjIJ3JSuEGBAfUMqUpFKRc
 dealer_password: "7788"
+game_names:
+  - Main Event
+  - Knockout Night
 player: &players
   - חן
   - קנטור


### PR DESCRIPTION
## Summary
- display the running bot version when /start is used and always refresh the metrics panel afterwards
- track the active game name with support for selecting from configured game presets and starting a fresh tournament from the metrics controls
- enrich tournament summaries/metrics with the selected game label and ensure the metrics view resurfaces after key actions

## Testing
- node --check server/index.js

------
https://chatgpt.com/codex/tasks/task_e_68caa0a38790832480d6906df645f623